### PR TITLE
improvement: Better initialization

### DIFF
--- a/Mongo.Migration.Tests/Migrations/Locators/TypeMigrationLocator_when_locate.cs
+++ b/Mongo.Migration.Tests/Migrations/Locators/TypeMigrationLocator_when_locate.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Mongo.Migration.Documents;
 using Mongo.Migration.Migrations.Locators;
 using Mongo.Migration.Tests.TestDoubles;
@@ -7,15 +8,15 @@ using NUnit.Framework;
 namespace Mongo.Migration.Tests.Migrations.Locators;
 
 [TestFixture]
-public class TypeMigrationLocatorWhenLocate
+public class TypeMigrationLocatorWhenLocate : IDisposable
 {
-    private TypeMigrationLocator _locator;
+    private readonly TypeMigrationLocator _locator;
+    private readonly ServiceProvider _serviceProvider;
 
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
+    public TypeMigrationLocatorWhenLocate()
     {
-        // Arrange
-        _locator = new TypeMigrationLocator(NullLogger<TypeMigrationLocator>.Instance);
+        _serviceProvider = new ServiceCollection().BuildServiceProvider();
+        _locator = new TypeMigrationLocator(NullLogger<TypeMigrationLocator>.Instance, _serviceProvider);
     }
 
     [Test]
@@ -70,5 +71,11 @@ public class TypeMigrationLocatorWhenLocate
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
         Assert.That(result[0], Is.TypeOf<TestDocumentWithTwoMigration002>());
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/Mongo.Migration.Tests/Mongo.Migration.Tests.csproj
+++ b/Mongo.Migration.Tests/Mongo.Migration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<LangVersion>13.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Mongo.Migration.Tests/TestDoubles/Database/TestDatabaseMigration_0_0_1.cs
+++ b/Mongo.Migration.Tests/TestDoubles/Database/TestDatabaseMigration_0_0_1.cs
@@ -3,12 +3,9 @@ using MongoDB.Driver;
 
 namespace Mongo.Migration.Tests.TestDoubles.Database;
 
-internal class TestDatabaseMigration001 : DatabaseMigration
+public class TestDatabaseMigration001 : DatabaseMigration
 {
-    public TestDatabaseMigration001()
-        : base("0.0.1")
-    {
-    }
+    public TestDatabaseMigration001() : base("0.0.1") { }
 
     public override Task UpAsync(IMongoDatabase db, CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/Mongo.Migration.Tests/TestDoubles/Database/TestDatabaseMigration_0_0_2.cs
+++ b/Mongo.Migration.Tests/TestDoubles/Database/TestDatabaseMigration_0_0_2.cs
@@ -3,12 +3,9 @@ using MongoDB.Driver;
 
 namespace Mongo.Migration.Tests.TestDoubles.Database;
 
-internal class TestDatabaseMigration002 : DatabaseMigration
+public class TestDatabaseMigration002 : DatabaseMigration
 {
-    public TestDatabaseMigration002()
-        : base("0.0.2")
-    {
-    }
+    public TestDatabaseMigration002() : base("0.0.2") { }
 
     public override Task UpAsync(IMongoDatabase db, CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/Mongo.Migration.Tests/TestDoubles/Database/TestDatabaseMigration_0_0_3.cs
+++ b/Mongo.Migration.Tests/TestDoubles/Database/TestDatabaseMigration_0_0_3.cs
@@ -3,12 +3,9 @@ using MongoDB.Driver;
 
 namespace Mongo.Migration.Tests.TestDoubles.Database;
 
-internal class TestDatabaseMigration003 : DatabaseMigration
+public class TestDatabaseMigration003 : DatabaseMigration
 {
-    public TestDatabaseMigration003()
-        : base("0.0.3")
-    {
-    }
+    public TestDatabaseMigration003() : base("0.0.3") { }
 
     public override Task UpAsync(IMongoDatabase db, CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/Mongo.Migration/Documents/Locators/CollectionLocator.cs
+++ b/Mongo.Migration/Documents/Locators/CollectionLocator.cs
@@ -1,14 +1,14 @@
 using Mongo.Migration.Documents.Attributes;
-#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#else
-using System.Collections.Immutable;
-#endif
 
 namespace Mongo.Migration.Documents.Locators;
 
-public class CollectionLocator : AbstractLocator<CollectionLocationInformation, Type>, ICollectionLocator
+public class CollectionLocator : AbstractLocator<CollectionLocationInformation, CollectionLocationAttribute>, ICollectionLocator
 {
+    protected override CollectionLocationInformation GetAttributeValue(CollectionLocationAttribute attribute)
+    {
+        return attribute.CollectionInformation;
+    }
+
     public override CollectionLocationInformation? GetLocateOrNull(Type identifier)
     {
         if (!LocatesDictionary.ContainsKey(identifier))
@@ -18,17 +18,6 @@ public class CollectionLocator : AbstractLocator<CollectionLocationInformation, 
 
         LocatesDictionary.TryGetValue(identifier, out var value);
         return value;
-    }
-
-    public override void Locate()
-    {
-        LocatesDictionary = LocateAttributes<CollectionLocationAttribute>()
-#if NET8_0_OR_GREATER
-            .ToFrozenDictionary(pair => pair.Item1, pair => pair.Item2.CollectionInformation);
-#else
-            .ToImmutableDictionary(pair => pair.Item1, pair => pair.Item2.CollectionInformation);
-#endif
-
     }
 
     public IDictionary<Type, CollectionLocationInformation> GetLocatesOrEmpty()

--- a/Mongo.Migration/Documents/Locators/ILocator.cs
+++ b/Mongo.Migration/Documents/Locators/ILocator.cs
@@ -5,6 +5,4 @@ public interface ILocator<TReturnType, in TTypeIdentifier>
     where TTypeIdentifier : class
 {
     TReturnType? GetLocateOrNull(TTypeIdentifier identifier);
-
-    void Locate();
 }

--- a/Mongo.Migration/Documents/Locators/RuntimeVersionLocator.cs
+++ b/Mongo.Migration/Documents/Locators/RuntimeVersionLocator.cs
@@ -1,27 +1,20 @@
-﻿#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#else
-using System.Collections.Immutable;
-#endif
+﻿using System.Collections.Frozen;
 using Mongo.Migration.Documents.Attributes;
 
 namespace Mongo.Migration.Documents.Locators;
 
-internal class RuntimeVersionLocator : AbstractLocator<DocumentVersion, Type>, IRuntimeVersionLocator
+internal class RuntimeVersionLocator : AbstractLocator<DocumentVersion, RuntimeVersionAttribute>, IRuntimeVersionLocator
 {
-#if NET8_0_OR_GREATER
     private readonly FrozenDictionary<Type, DocumentVersion> _codeDefinedDictionary;
-#else
-    private readonly ImmutableDictionary<Type, DocumentVersion> _codeDefinedDictionary;
-#endif
 
     internal RuntimeVersionLocator(IEnumerable<KeyValuePair<Type, DocumentVersion>> alreadyDefinedRuntimeVersions)
     {
-#if NET8_0_OR_GREATER
         _codeDefinedDictionary = alreadyDefinedRuntimeVersions.ToFrozenDictionary();
-#else
-        _codeDefinedDictionary = alreadyDefinedRuntimeVersions.ToImmutableDictionary();
-#endif
+    }
+
+    protected override DocumentVersion GetAttributeValue(RuntimeVersionAttribute attribute)
+    {
+        return attribute.Version;
     }
 
     public override DocumentVersion? GetLocateOrNull(Type identifier)
@@ -31,21 +24,6 @@ internal class RuntimeVersionLocator : AbstractLocator<DocumentVersion, Type>, I
             return version;
         }
 
-        if (LocatesDictionary.TryGetValue(identifier, out version))
-        {
-            return version;
-        }
-
-        return null;
-    }
-
-    public override void Locate()
-    {
-        LocatesDictionary = LocateAttributes<RuntimeVersionAttribute>()
-#if NET8_0_OR_GREATER
-            .ToFrozenDictionary(pair => pair.Item1, pair => pair.Item2.Version);
-#else
-            .ToImmutableDictionary(pair => pair.Item1, pair => pair.Item2.Version);
-#endif
+        return base.GetLocateOrNull(identifier);
     }
 }

--- a/Mongo.Migration/Documents/Locators/StartUpVersionLocator.cs
+++ b/Mongo.Migration/Documents/Locators/StartUpVersionLocator.cs
@@ -1,32 +1,11 @@
-﻿#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#else
-using System.Collections.Immutable;
-#endif
-using Mongo.Migration.Documents.Attributes;
+﻿using Mongo.Migration.Documents.Attributes;
 
 namespace Mongo.Migration.Documents.Locators;
 
-internal class StartUpVersionLocator : AbstractLocator<DocumentVersion, Type>, IStartUpVersionLocator
+internal class StartUpVersionLocator : AbstractLocator<DocumentVersion, StartUpVersionAttribute>, IStartUpVersionLocator
 {
-    public override DocumentVersion? GetLocateOrNull(Type identifier)
+    protected override DocumentVersion GetAttributeValue(StartUpVersionAttribute attribute)
     {
-        if (!LocatesDictionary.ContainsKey(identifier))
-        {
-            return null;
-        }
-
-        LocatesDictionary.TryGetValue(identifier, out var value);
-        return value;
-    }
-
-    public override void Locate()
-    {
-        LocatesDictionary = LocateAttributes<StartUpVersionAttribute>()
-#if NET8_0_OR_GREATER
-            .ToFrozenDictionary(pair => pair.Item1, pair => pair.Item2.Version);
-#else
-            .ToImmutableDictionary(pair => pair.Item1, pair => pair.Item2.Version);
-#endif
+        return attribute.Version;
     }
 }

--- a/Mongo.Migration/Migrations/Document/DocumentMigration.cs
+++ b/Mongo.Migration/Migrations/Document/DocumentMigration.cs
@@ -5,14 +5,17 @@ namespace Mongo.Migration.Migrations.Document;
 
 public abstract class DocumentMigration<TClass> : IDocumentMigration
 {
-    protected DocumentMigration(string version)
+    protected DocumentMigration(DocumentVersion version)
     {
-        Version = DocumentVersion.Parse(version.AsSpan());
+        Version = version;
     }
+
+    protected DocumentMigration(ReadOnlySpan<char> span)
+        : this(DocumentVersion.Parse(span)) { }
 
     public DocumentVersion Version { get; }
 
-    public Type Type => typeof(TClass);
+    public Type Type { get; } = typeof(TClass);
 
     public abstract void Up(BsonDocument document);
 

--- a/Mongo.Migration/Migrations/Locators/DatabaseTypeMigrationDependencyLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/DatabaseTypeMigrationDependencyLocator.cs
@@ -5,23 +5,6 @@ namespace Mongo.Migration.Migrations.Locators;
 
 internal class DatabaseTypeMigrationDependencyLocator : TypeMigrationDependencyLocator<IDatabaseMigration>, IDatabaseTypeMigrationDependencyLocator
 {
-    private IDictionary<Type, IReadOnlyCollection<IDatabaseMigration>>? _migrations;
     public DatabaseTypeMigrationDependencyLocator(ILogger<DatabaseTypeMigrationDependencyLocator> logger, IServiceProvider serviceProvider)
         : base(logger, serviceProvider) { }
-
-    protected override IDictionary<Type, IReadOnlyCollection<IDatabaseMigration>> Migrations
-    {
-        get
-        {
-            if (_migrations == null)
-            {
-                Locate();
-            }
-
-            return _migrations!;
-        }
-        set => _migrations = value;
-    }
-
-    
 }

--- a/Mongo.Migration/Migrations/Locators/IDatabaseTypeMigrationDependencyLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/IDatabaseTypeMigrationDependencyLocator.cs
@@ -2,6 +2,4 @@
 
 namespace Mongo.Migration.Migrations.Locators;
 
-internal interface IDatabaseTypeMigrationDependencyLocator : IMigrationLocator<IDatabaseMigration>
-{
-}
+internal interface IDatabaseTypeMigrationDependencyLocator : IMigrationLocator<IDatabaseMigration>;

--- a/Mongo.Migration/Migrations/Locators/IMigrationLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/IMigrationLocator.cs
@@ -13,5 +13,5 @@ public interface IMigrationLocator<out TMigrationType>
 
     DocumentVersion GetLatestVersion(Type type);
 
-    void Locate();
+    void Initialize();
 }

--- a/Mongo.Migration/Migrations/Locators/TypeMigrationDependencyLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/TypeMigrationDependencyLocator.cs
@@ -1,63 +1,10 @@
-﻿using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Mongo.Migration.Extensions;
+﻿using Microsoft.Extensions.Logging;
 
 namespace Mongo.Migration.Migrations.Locators;
 
 internal class TypeMigrationDependencyLocator<TMigrationType> : MigrationLocator<TMigrationType>
     where TMigrationType : class, IMigration
 {
-    private readonly IServiceProvider _serviceProvider;
-
     public TypeMigrationDependencyLocator(ILogger<TypeMigrationDependencyLocator<TMigrationType>> logger, IServiceProvider serviceProvider)
-        : base(logger)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
-    public override void Locate()
-    {
-        var migrationTypes =
-            (from assembly in Assemblies
-                from type in assembly.GetTypes()
-                where typeof(TMigrationType).IsAssignableFrom(type) && !type.IsAbstract
-                select type).Distinct(new TypeComparer());
-
-        Migrations = migrationTypes.Select(GetMigrationInstance).ToMigrationDictionary();
-    }
-
-    private TMigrationType GetMigrationInstance(Type type)
-    {
-        ConstructorInfo[] constructors = type.GetConstructors();
-
-        if (constructors.Length > 0)
-        {
-            var args = constructors
-                .First()
-                .GetParameters()
-                .Select(parameterInfo => _serviceProvider.GetRequiredService(parameterInfo.ParameterType))
-                .ToArray();
-
-            return Activator.CreateInstance(type, args) as TMigrationType
-                   ?? throw new InvalidOperationException($"Cannot create {type} migration");
-        }
-
-        return Activator.CreateInstance(type) as TMigrationType
-               ?? throw new InvalidOperationException($"Cannot create {type} migration");
-    }
-
-    private class TypeComparer : IEqualityComparer<Type>
-    {
-        public bool Equals(Type? x, Type? y)
-        {
-            return x?.AssemblyQualifiedName == y?.AssemblyQualifiedName;
-        }
-
-        public int GetHashCode(Type obj)
-        {
-            return obj.AssemblyQualifiedName?.GetHashCode()
-                   ?? throw new InvalidOperationException($"Cannot get AssemblyQualifiedName from {obj}");
-        }
-    }
+        : base(logger, serviceProvider) { }
 }

--- a/Mongo.Migration/Migrations/Locators/TypeMigrationLocator.cs
+++ b/Mongo.Migration/Migrations/Locators/TypeMigrationLocator.cs
@@ -1,25 +1,9 @@
 ﻿using Microsoft.Extensions.Logging;
-using Mongo.Migration.Extensions;
 using Mongo.Migration.Migrations.Document;
 
 namespace Mongo.Migration.Migrations.Locators;
 
 internal class TypeMigrationLocator : MigrationLocator<IDocumentMigration>
 {
-    public TypeMigrationLocator(ILogger<TypeMigrationLocator> logger) : base(logger) { }
-
-    public override void Locate()
-    {
-        var migrationTypes =
-            (from assembly in Assemblies
-                from type in assembly.GetTypes()
-                where typeof(IDocumentMigration).IsAssignableFrom(type) && !type.IsAbstract
-                select type).Distinct();
-
-        Migrations = migrationTypes
-            .Select(t =>
-                Activator.CreateInstance(t) as IDocumentMigration
-                ?? throw new InvalidOperationException($"Cannot create {t} document migration"))
-            .ToMigrationDictionary();
-    }
+    public TypeMigrationLocator(ILogger<TypeMigrationLocator> logger, IServiceProvider serviceProvider) : base(logger, serviceProvider) { }
 }

--- a/Mongo.Migration/Mongo.Migration.csproj
+++ b/Mongo.Migration/Mongo.Migration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<LangVersion>13.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Mongo.Migration/Services/MigrationService.cs
+++ b/Mongo.Migration/Services/MigrationService.cs
@@ -6,6 +6,7 @@ using Mongo.Migration.Documents;
 using Mongo.Migration.Documents.Serializers;
 using Mongo.Migration.Migrations.Database;
 using Mongo.Migration.Migrations.Document;
+using Mongo.Migration.Migrations.Locators;
 using Mongo.Migration.Startup;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
@@ -40,6 +41,9 @@ internal class MigrationService : IMigrationService
         {
             MigrationBsonSerializerProvider migrationSerializerProvider = _provider.GetRequiredService<MigrationBsonSerializerProvider>();
             BsonSerializer.RegisterSerializationProvider(migrationSerializerProvider);
+
+            var documentMigrationLocator = _provider.GetRequiredService<IMigrationLocator<IDocumentMigration>>();
+            documentMigrationLocator.Initialize();
         }
     }
 


### PR DESCRIPTION
- Make all migration locator thread safe
- Early init runtime migration
- Make all attribute locator thread safe
- Remove code duplication
- remove .net7 support
- Force migrations to be public